### PR TITLE
Replace sendInputEventWithName

### DIFF
--- a/ios/RCTCamera.m
+++ b/ios/RCTCamera.m
@@ -1,4 +1,5 @@
 #import <React/RCTBridge.h>
+#import <React/RCTComponentEvent.h>
 #import "RCTCamera.h"
 #import "RCTCameraManager.h"
 #import <React/RCTLog.h>
@@ -129,14 +130,16 @@
         {
             [self.camFocus removeFromSuperview];
         }
-        NSDictionary *event = @{
-          @"target": self.reactTag,
+        NSDictionary *body = @{
           @"touchPoint": @{
             @"x": [NSNumber numberWithDouble:touchPoint.x],
             @"y": [NSNumber numberWithDouble:touchPoint.y]
           }
         };
-        [self.bridge.eventDispatcher sendInputEventWithName:@"focusChanged" body:event];
+        RCTComponentEvent *event = [[RCTComponentEvent alloc] initWithName:@"focusChanged"
+                                                              viewTag:self.reactTag
+                                                              body:body];
+        [self.bridge.eventDispatcher sendEvent:event];
 
         // Show animated rectangle on the touched area
         if (_defaultOnFocusComponent) {

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -1,6 +1,7 @@
 #import "RCTCameraManager.h"
 #import "RCTCamera.h"
 #import <React/RCTBridge.h>
+#import <React/RCTComponentEvent.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTUtils.h>
 #import <React/RCTLog.h>
@@ -1025,13 +1026,14 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
             zoomFactor = 1.0f;
         }
 
-        NSDictionary *event = @{
-          @"target": reactTag,
+        NSDictionary *body = @{
           @"zoomFactor": [NSNumber numberWithDouble:zoomFactor],
           @"velocity": [NSNumber numberWithDouble:velocity]
         };
-
-        [self.bridge.eventDispatcher sendInputEventWithName:@"zoomChanged" body:event];
+        RCTComponentEvent *event = [[RCTComponentEvent alloc] initWithName:@"zoomChanged"
+                                                              viewTag:reactTag
+                                                              body:body];
+        [self.bridge.eventDispatcher sendEvent:event];
 
         device.videoZoomFactor = zoomFactor;
         [device unlockForConfiguration];

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/lwansbrough/react-native-camera.git"
   },
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A Camera component for React Native. Also reads barcodes.",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "peerDependencies": {


### PR DESCRIPTION
`sendInputEventWithName` was deprecated and removed in React-Native 0.60.0 so this replaces it based on this:
https://github.com/facebook/react-native-fbsdk/commit/3eb205e1d2a7ae738ef06ea2167687df461490a7